### PR TITLE
properly initialize unnamed constructors

### DIFF
--- a/AST/implementation/implementation.dart
+++ b/AST/implementation/implementation.dart
@@ -518,12 +518,15 @@ csharp += Naming.escapeFixedWords(processEntity(entity));
   static String processInstanceCreationExpression(
       InstanceCreationExpression expression) {
     var csharp = "";
+    var isNamedConstructor = expression.staticElement.name != "";
     for (var entity in expression.childEntities) {
       csharp += processEntity(entity);
     }
+    
     // TODO: No such thing as named constructors in C#
     // Will need to look at Static Method calls without the new.
-    //if (!csharp.startsWith('new ')) csharp = 'new ' + csharp;
+    if (!csharp.startsWith('new ') && !isNamedConstructor) 
+      csharp = 'new ' + csharp;
     return csharp;
   }
 


### PR DESCRIPTION
since we handle constant unnamed dart constructors as normal constructors in c#, we need to ensure to initialize them unlike their named counterparts